### PR TITLE
fix: sort posts by pubDate from newest to oldest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,6 @@
-# Astro Starter Kit: Minimal
+# My Musings and Writing - schalkneethling.com
 
-```sh
-npm create astro@latest -- --template minimal
-```
-
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/minimal)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/minimal)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/minimal/devcontainer.json)
-
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
-
-## 🚀 Project Structure
-
-Inside of your Astro project, you'll see the following folders and files:
-
-```text
-/
-├── public/
-├── src/
-│   └── pages/
-│       └── index.astro
-└── package.json
-```
-
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
-
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
-
-Any static assets, like images, can be placed in the `public/` directory.
+This is the code for my personal blog where I write about my thoughts, experiences, and learnings. I use this blog as a way to document my journey and share my knowledge with others.
 
 ## 🧞 Commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "astros",
+  "name": "schalkneethling.com",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "astros",
+      "name": "schalkneethling.com",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/mdx": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "astros",
+  "name": "schalkneethling.com",
   "type": "module",
   "version": "0.0.1",
   "scripts": {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,2 @@
+/// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,6 +1,5 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
-import BlogPost from "../components/BlogPost.astro";
 import Tags from "@components/Tags.astro";
 import Posts from "@components/Posts.astro";
 
@@ -8,6 +7,11 @@ const pageTitle = "My thoughts, ideas, experiences, and ramblings";
 
 const posts = await Astro.glob("../pages/posts/*.{md,mdx}");
 const tags = [...new Set(posts.map((post) => post.frontmatter.tags).flat())];
+const sortedPosts = posts.toSorted(
+  (a, b) =>
+    new Date(b.frontmatter.pubDate).getTime() -
+    new Date(a.frontmatter.pubDate).getTime()
+);
 ---
 
 <BaseLayout pageTitle={pageTitle}>
@@ -57,7 +61,7 @@ const tags = [...new Set(posts.map((post) => post.frontmatter.tags).flat())];
 
     <section aria-labelledby="chronological">
       <h2 id="chronological">Browse all posts</h2>
-      <Posts posts={posts} />
+      <Posts posts={sortedPosts} />
     </section>
   </main>
 </BaseLayout>

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,11 +1,17 @@
 import rss, { pagesGlobToRssItems } from "@astrojs/rss";
 
+const defaultSort = await pagesGlobToRssItems(import.meta.glob("./**/*.md"));
+const sortedPosts = defaultSort.toSorted(
+  (a, b) => new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime()
+);
+
 export async function GET(context) {
   return rss({
     title: "Schalk Neethling - Open Web, Open Source, and Web Accessibility",
-    description: "My thoughts, ideas, experiences, and ramblings about code, life, and the open web",
+    description:
+      "My thoughts, ideas, experiences, and ramblings about code, life, and the open web",
     site: context.site,
-    items: await pagesGlobToRssItems(import.meta.glob("./**/*.md")),
+    items: sortedPosts,
     customData: `<language>en-us</language>`,
   });
 }


### PR DESCRIPTION
Posts are now sorted from the newest to the oldest on the blog and RSS.