### PR TITLE
fix: reduce mobile typescale and fix heading overflow

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,6 +17,9 @@
   --color-surface-elevated: light-dark(#fff, #343434);
   --color-border: light-dark(#d5d5d5, #4e4e4e);
 
+  /* Reduce mobile typescale from 1.25 (major third) to 1.2 (minor third) */
+  --minimalist-typography-scale-mobile: 1.2;
+
   /* Primary accent colors using light-dark() */
   --color-accent: light-dark(#b04198, #dca2cb);
   --color-accent-hover: light-dark(#561c4a, #ebc7e0);
@@ -46,6 +49,7 @@
 body {
   background-color: var(--color-background);
   color: var(--color-text);
+  overflow-wrap: anywhere;
 }
 
 /* Link colors using semantic tokens */


### PR DESCRIPTION
## Summary

- Reduces the mobile typography scale factor from `1.25` (major third) to `1.2` (minor third), bringing h1 on mobile from ~49px down to ~40px — a ~19% reduction that makes headings feel proportionate on narrow viewports
- Adds `overflow-wrap: anywhere` to `body` as a safety net, preventing long titles from pushing the layout wider than the viewport

Both changes are made in `src/styles/global.css` via CSS custom property override, keeping the `src/styles/minimalist/` library untouched.

Closes #1218

## Mobile heading sizes before/after

| Heading | Before | After |
|---------|--------|-------|
| h1 | 3.052rem (49px) | 2.488rem (40px) |
| h2 | 2.441rem (39px) | 2.074rem (33px) |
| h3 | 1.953rem (31px) | 1.728rem (28px) |

Desktop scale (1.33) is unchanged.

## Test plan

- [x] View a blog post on a 375px viewport and confirm the h1 title fits without overflowing
- [x] Check the homepage and other pages for visual regressions
- [ ] Run `npx playwright test` and confirm all accessibility checks pass