### PR TITLE
update: increase masonry gap to 24 and move featured accent border top

### DIFF
--- a/src/components/Projects/FeaturedProjects.astro
+++ b/src/components/Projects/FeaturedProjects.astro
@@ -64,7 +64,7 @@ const projects = FEATURED_NAMES.map((name) => {
 
 <section aria-labelledby="featured-projects">
   <h2 id="featured-projects" class="gradient-text">Featured Projects</h2>
-  <masonry-grid-lanes min-column-width="280" gap="16">
+  <masonry-grid-lanes min-column-width="280" gap="24">
     {
       projects.map((project) => (
         <ProjectCard

--- a/src/components/Projects/ProjectCard.astro
+++ b/src/components/Projects/ProjectCard.astro
@@ -77,7 +77,7 @@ const { name, description, url, language, stars, imageUrl, featured } =
   }
 
   .project-card--featured {
-    border-inline-start: var(--size-4) solid var(--color-accent);
+    border-block-start: var(--size-4) solid var(--color-accent);
   }
 
   .project-card-image {

--- a/src/components/Projects/RandomProjects.astro
+++ b/src/components/Projects/RandomProjects.astro
@@ -14,7 +14,7 @@ const { projects } = Astro.props;
   <p>A random selection from my GitHub repos, reshuffled with every deploy.</p>
   {
     projects.length > 0 ? (
-      <masonry-grid-lanes min-column-width="260" gap="16">
+      <masonry-grid-lanes min-column-width="260" gap="24">
         {projects.map((project) => (
           <ProjectCard
             name={project.name}


### PR DESCRIPTION
Give cards more breathing room with a larger gap (16 → 24) and move the featured card accent stripe from the left edge to the top edge.