### PR TITLE
feat: add link to source on GitHub

### DIFF
--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -46,7 +46,7 @@ const tags = frontmatter.tags;
     <footer class="post-footer">
       <p class="suggest-edit">
         Spot something off or want to improve this article?
-        <a href={sourceEditUrl}>Suggest an edit on GitHub</a>.
+        <a href={sourceEditUrl} rel="noopener noreferrer">Suggest an edit on GitHub</a>.
       </p>
       <h2 class="visually-hidden">Tags</h2>
       <Tags tags={tags} />

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -2,7 +2,23 @@
 import BaseLayout from "./BaseLayout.astro";
 import Tags from "../components/Tags.astro";
 
-const { frontmatter } = Astro.props;
+interface Props {
+  frontmatter: {
+    author: string;
+    canonical?: string;
+    description: string;
+    image?: {
+      alt: string;
+      url: string;
+    };
+    pubDate: Date;
+    tags: string[];
+    title: string;
+  };
+  sourceEditUrl: string;
+}
+
+const { frontmatter, sourceEditUrl } = Astro.props as Props;
 const tags = frontmatter.tags;
 ---
 
@@ -28,6 +44,10 @@ const tags = frontmatter.tags;
     }
     <slot />
     <footer class="post-footer">
+      <p class="suggest-edit">
+        Spot something off or want to improve this article?
+        <a href={sourceEditUrl}>Suggest an edit on GitHub</a>.
+      </p>
       <h2 class="visually-hidden">Tags</h2>
       <Tags tags={tags} />
     </footer>
@@ -61,5 +81,9 @@ const tags = frontmatter.tags;
     border-block-start: 1px solid var(--color-border);
     margin-block-start: var(--size-32, 2rem);
     padding-block-start: var(--size-24, 1.5rem);
+  }
+
+  .suggest-edit {
+    margin-block-end: var(--size-24, 1.5rem);
   }
 </style>

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -1,8 +1,26 @@
 ---
 import { render } from "astro:content";
 import type { CollectionEntry } from "astro:content";
+import { existsSync } from "node:fs";
 import { getPublishedPosts } from "../../lib/posts";
 import MarkdownPostLayout from "../../layouts/MarkdownPostLayout.astro";
+
+const REPO_EDIT_BASE_URL = "https://github.com/schalkneethling/schalkneethling.com/edit/main/";
+
+function getPostSourcePath(postId: string) {
+  const markdownPath = `src/content/posts/${postId}.md`;
+  const mdxPath = `src/content/posts/${postId}.mdx`;
+
+  if (existsSync(new URL(`../../../${markdownPath}`, import.meta.url))) {
+    return markdownPath;
+  }
+
+  if (existsSync(new URL(`../../../${mdxPath}`, import.meta.url))) {
+    return mdxPath;
+  }
+
+  return markdownPath;
+}
 
 export async function getStaticPaths() {
   const posts = await getPublishedPosts();
@@ -18,8 +36,10 @@ interface Props {
 
 const { post } = Astro.props;
 const { Content } = await render(post);
+const sourcePath = getPostSourcePath(post.id);
+const sourceEditUrl = `${REPO_EDIT_BASE_URL}${sourcePath}`;
 ---
 
-<MarkdownPostLayout frontmatter={post.data}>
+<MarkdownPostLayout frontmatter={post.data} sourceEditUrl={sourceEditUrl}>
   <Content />
 </MarkdownPostLayout>

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -1,25 +1,13 @@
 ---
 import { render } from "astro:content";
 import type { CollectionEntry } from "astro:content";
-import { existsSync } from "node:fs";
 import { getPublishedPosts } from "../../lib/posts";
 import MarkdownPostLayout from "../../layouts/MarkdownPostLayout.astro";
 
 const REPO_EDIT_BASE_URL = "https://github.com/schalkneethling/schalkneethling.com/edit/main/";
 
-function getPostSourcePath(postId: string) {
-  const markdownPath = `src/content/posts/${postId}.md`;
-  const mdxPath = `src/content/posts/${postId}.mdx`;
-
-  if (existsSync(new URL(`../../../${markdownPath}`, import.meta.url))) {
-    return markdownPath;
-  }
-
-  if (existsSync(new URL(`../../../${mdxPath}`, import.meta.url))) {
-    return mdxPath;
-  }
-
-  return markdownPath;
+function getPostSourcePath(filePath?: string) {
+  return filePath?.replace(/^src\//, "src/") ?? "";
 }
 
 export async function getStaticPaths() {
@@ -36,7 +24,7 @@ interface Props {
 
 const { post } = Astro.props;
 const { Content } = await render(post);
-const sourcePath = getPostSourcePath(post.id);
+const sourcePath = getPostSourcePath(post.filePath);
 const sourceEditUrl = `${REPO_EDIT_BASE_URL}${sourcePath}`;
 ---
 


### PR DESCRIPTION
## Summary
- add a GitHub edit link to the footer of each post
- derive the correct source path for both markdown and MDX posts
- keep unrelated untracked post drafts out of this PR

Closes #1030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Blog posts now include a "suggest edit" link that enables readers to propose corrections and improvements by directly accessing the source content in the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->