### PR TITLE
Complete starter project content

### DIFF
--- a/src/content/projects/common-components.md
+++ b/src/content/projects/common-components.md
@@ -5,7 +5,18 @@ category: "main"
 order: 10
 repoUrl: "https://github.com/schalkneethling/common-components"
 imageUrl: "https://opengraph.githubassets.com/bbda519087a7bfd65cf5cb287d564c489f6005c2993c92bfb3103aff2c288aa2/schalkneethling/common-components"
+liveUrl: "https://schalkneethling.github.io/common-components/"
 language: "HTML"
 stars: 3
 technologies: ["HTML", "Web Components", "CSS"]
+goalDocUrl: "https://github.com/schalkneethling/common-components/blob/main/GOAL.md"
+roadmapDocUrl: "https://github.com/schalkneethling/common-components/blob/main/ROADMAP.md"
+whatAndWhy: "A component catalog evolving into Fiori: a practical library of accessible, platform-first web components and experiments. It exists both as a useful component collection and as a real project where sibling tools can prove themselves."
+goalSummary: "Make real, usable web platform components that people can copy, study, adapt, and use, while clearly documenting readiness, accessibility behavior, browser support, dependencies, and modern platform feature requirements."
+currentState: "The repo has a Vite-powered catalog, multiple component demos, a React interoperability app, and a roadmap that treats alertbox as the first reference-quality component."
+nextSteps:
+  - "Finish the pnpm and documentation turnaround so the project is coherent from a fresh checkout."
+  - "Add component maturity and support-status tables to separate production candidates from experiments."
+  - "Use alertbox to establish the documentation, testing, and accessibility bar for future components."
+contributionGuidance: "Contributions should improve component clarity, accessibility, tests, and documentation. Label experiments honestly and keep platform components as the source of truth even when React examples are added."
 ---

--- a/src/content/projects/create-project-calavera.md
+++ b/src/content/projects/create-project-calavera.md
@@ -5,7 +5,17 @@ category: "main"
 order: 7
 repoUrl: "https://github.com/schalkneethling/create-project-calavera"
 imageUrl: "https://repository-images.githubusercontent.com/903176922/d1319ba4-0fc9-4df5-8c96-f8c59c9be799"
+liveUrl: "https://calavera.schalkneethling.com"
 language: "JavaScript"
 stars: 7
 technologies: ["JavaScript", "CLI", "Project Scaffolding"]
+goalDocUrl: "https://github.com/schalkneethling/create-project-calavera/blob/main/GOAL.md"
+whatAndWhy: "A recipe-driven tooling assistant for web projects. It exists to make linting, formatting, type-checking, CSS quality, and integration choices repeatable without turning Calavera into an application framework or starter kit."
+goalSummary: "Help developers compose, apply, inspect, and refresh project tooling recipes through a CLI and web composer, with checked-in intent, dry runs, JSON output, and catalog-driven integrations."
+currentState: "The project centers on the recipe CLI, a shared integration catalog, and the Calavera Composer site, with modern, classic, and minimal tooling profiles."
+nextSteps:
+  - "Preserve parity between the CLI and web composer as integrations evolve."
+  - "Improve generated tooling quality while keeping files readable and reviewable."
+  - "Keep automation-friendly commands, dry runs, and JSON output stable for agents and CI."
+contributionGuidance: "Start with catalog-level changes and tests for generated dependencies, scripts, and managed files. New integrations should stay small, explicit, and easy to inspect in dry-run output."
 ---

--- a/src/content/projects/css-benchpress.md
+++ b/src/content/projects/css-benchpress.md
@@ -8,4 +8,13 @@ imageUrl: "https://repository-images.githubusercontent.com/1272350957/e3bc5088-f
 language: "TypeScript"
 stars: 9
 technologies: ["TypeScript", "CSS", "Performance"]
+goalDocUrl: "https://github.com/schalkneethling/css-benchpress/blob/main/GOAL.md"
+whatAndWhy: "A CSS performance research tool that grows realistic web-platform cases until measurable regressions appear. It exists to turn vague concerns about expensive CSS patterns into shareable, reproducible evidence."
+goalSummary: "Help CSS authors, tooling builders, and browser engineers discover where selectors, custom properties, layout movement, visual effects, and mutation patterns become performance problems."
+currentState: "The first milestone is a Node.js and TypeScript CLI prototype using Playwright to run framework-free fixtures, gather standard Performance API and Chromium trace signals, detect thresholds, and save reports and repros."
+nextSteps:
+  - "Ship the initial case corpus for selectors, custom property fanout, @property, layout instability, and paint-heavy effects."
+  - "Tune thresholds against real examples and reviewed reports."
+  - "Make generated artifacts clear enough to share with DevTools authors and browser engineers."
+contributionGuidance: "Useful contributions are focused, realistic CSS cases with clear scaling dimensions and expected signals. Avoid leaderboard-style comparisons; the goal is credible diagnosis and reproducibility."
 ---

--- a/src/content/projects/css-custom-property-inspector.md
+++ b/src/content/projects/css-custom-property-inspector.md
@@ -8,4 +8,12 @@ imageUrl: "https://opengraph.githubassets.com/8ee606d555f413fb3414dff7e8d8280ae7
 language: "TypeScript"
 stars: 0
 technologies: ["TypeScript", "VS Code", "CSS"]
+whatAndWhy: "A VS Code-compatible extension for inspecting CSS custom properties from the editor. It exists because design-token systems are easier to maintain when authors can see values, definitions, fallbacks, and reference chains without manually searching a workspace."
+goalSummary: "Give CSS, SCSS, Less, and HTML authors useful hover feedback for custom property definitions, resolved var() chains, color swatches, selector context, and clickable source locations."
+currentState: "The extension scans workspace stylesheets and HTML style blocks, keeps an index fresh through file watching, and exposes configurable hover behavior for resolved values, depth, include types, excludes, and file links."
+nextSteps:
+  - "Add a project GOAL.md so the long-term editor-tooling direction is captured outside the README."
+  - "Expand real-workspace test coverage around nested references, media-query context, and fallback handling."
+  - "Clarify compatibility and release expectations for VS Code, VS Codium, Cursor, and Windsurf users."
+contributionGuidance: "Strong contributions include reproducible CSS workspaces, hover-output expectations, and fixes that keep indexing accurate without making editor feedback noisy."
 ---

--- a/src/content/projects/css-expect.md
+++ b/src/content/projects/css-expect.md
@@ -8,4 +8,13 @@ imageUrl: "https://repository-images.githubusercontent.com/1258634645/be6e459a-0
 language: "TypeScript"
 stars: 4
 technologies: ["TypeScript", "CSS", "Testing"]
+goalDocUrl: "https://github.com/schalkneethling/css-expect/blob/main/GOAL.md"
+whatAndWhy: "A small browser-backed expectation library for CSS custom functions, and eventually native CSS mixins. It exists because emerging CSS logic should be tested by the browser that computes it, not by a JavaScript reimplementation guessing at CSS semantics."
+goalSummary: "Make it practical to write trustworthy tests for native CSS custom functions by loading CSS, applying a real property context, reading computed values, and returning diagnostics that explain browser support and expectation failures."
+currentState: "The project is focused on proving the custom-function API against current Chromium support, with Playwright as the browser automation layer and a conservative package surface for early adopters."
+nextSteps:
+  - "Keep README examples and generated diagnostics aligned with the shipped API."
+  - "Validate behavior when target CSS features are unsupported and make skip-or-fail policies clear."
+  - "Prepare the package for a careful first public release."
+contributionGuidance: "Useful contributions are browser-backed test cases, clearer diagnostics, and examples that show real custom-function usage. Avoid adding broad runner integrations until the core API has settled."
 ---

--- a/src/content/projects/css-media-pseudo-polyfill.md
+++ b/src/content/projects/css-media-pseudo-polyfill.md
@@ -8,4 +8,12 @@ imageUrl: "https://opengraph.githubassets.com/3e4f3b4145c5fce35fd49cf5f9b8380610
 language: "TypeScript"
 stars: 3
 technologies: ["TypeScript", "CSS", "Polyfill"]
+whatAndWhy: "A progressive polyfill for media state pseudo-classes such as :playing, :paused, :seeking, :buffering, :stalled, and :muted. It exists so authors can write state-driven media styles now while browsers continue filling support gaps."
+goalSummary: "Detect unsupported media pseudo-classes, preserve authored cascade intent by rewriting CSS into specificity-equivalent class selectors, and update audio and video elements as their playback state changes."
+currentState: "The package supports per-pseudo-class feature detection, inline and same-origin linked stylesheet rewriting, MutationObserver-based media discovery, pure state computation, and explicit handling for non-polyfillable :volume-locked."
+nextSteps:
+  - "Add GOAL.md and ROADMAP.md so the polyfill scope and future removal path are captured outside the README."
+  - "Keep tests focused on CSS rewriting, state computation, same-origin stylesheet behavior, and dynamic media elements."
+  - "Document browser support and FOUC tradeoffs as native media pseudo-class support changes."
+contributionGuidance: "Helpful contributions include reduced browser cases, css-tree rewriting tests, and media-state edge cases. Keep the polyfill progressive and avoid expanding into behavior the DOM cannot observe."
 ---

--- a/src/content/projects/css-property-type-validator.md
+++ b/src/content/projects/css-property-type-validator.md
@@ -5,7 +5,18 @@ category: "main"
 order: 6
 repoUrl: "https://github.com/schalkneethling/css-property-type-validator"
 imageUrl: "https://repository-images.githubusercontent.com/1198765576/0966a7fe-ab8b-4e6d-997e-5dbb136ff80d"
+liveUrl: "https://typedcss-validator.schalkneethling.com"
 language: "TypeScript"
 stars: 10
 technologies: ["TypeScript", "CSS", "Tooling"]
+goalDocUrl: "https://github.com/schalkneethling/css-property-type-validator/blob/main/GOAL.md"
+roadmapDocUrl: "https://github.com/schalkneethling/css-property-type-validator/blob/main/ROADMAP.md"
+whatAndWhy: "A validator for typed CSS custom properties and @property registrations. It exists because invalid registrations and incompatible var() usage can silently change rendered output, especially in token-heavy systems."
+goalSummary: "Make typed custom properties easier to adopt by catching invalid @property descriptors, incompatible assignments, and risky var() usage through a shared validation core that can power a CLI, Stylelint plugin, editor tooling, and a browser UI."
+currentState: "The core validates registrations, direct assignments, multiple registered var() usages, simple fallback branches, imported registries, and a first beta Stylelint plugin."
+nextSteps:
+  - "Improve support for whitespace and fallback-toggle custom property patterns."
+  - "Add clearer remediation context to diagnostics."
+  - "Harden Stylelint beta behavior through real-project feedback and config-file based registry discovery."
+contributionGuidance: "The best contributions include reduced CSS examples, expected diagnostics, and tests against the shared core. Keep behavior conservative and prefer skipping uncertain cases over noisy false positives."
 ---

--- a/src/content/projects/masonry-gridlanes-wc.md
+++ b/src/content/projects/masonry-gridlanes-wc.md
@@ -8,4 +8,13 @@ imageUrl: "https://opengraph.githubassets.com/69ce968cb624e4cde1f74edf54d4dd27c0
 language: "JavaScript"
 stars: 11
 technologies: ["JavaScript", "Web Components", "CSS Grid"]
+goalDocUrl: "https://github.com/schalkneethling/masonry-gridlanes-wc/blob/main/GOAL.md"
+whatAndWhy: "A native-first Web Component for masonry layouts that tracks the emerging CSS Grid Lanes model. It exists to let real sites experiment with platform-shaped masonry today, while keeping markup and CSS close enough to future native support that removal stays realistic."
+goalSummary: "Make CSS Grid Lanes masonry practical for production sites through a light-DOM custom element that prefers native support and offers a focused, spec-shaped JavaScript fallback where the platform is not ready yet."
+currentState: "The package has a 0.1.x foundation with column masonry, row-mode experimentation, demos, Playwright coverage, and Pretext-powered helpers for text-heavy layouts."
+nextSteps:
+  - "Strengthen confidence in column masonry and text-heavy layouts through focused tests and demos."
+  - "Improve row-mode behavior while keeping its constraints clear."
+  - "Keep the fallback honest about what it supports instead of presenting it as a full CSS Grid Lanes polyfill."
+contributionGuidance: "Good contributions are small behavior fixes, demo improvements, or tests that clarify native-vs-fallback expectations. Open an issue first when changing fallback layout behavior."
 ---

--- a/src/content/projects/refined-plan-mode.md
+++ b/src/content/projects/refined-plan-mode.md
@@ -8,4 +8,13 @@ imageUrl: "https://opengraph.githubassets.com/29924b3161f878801383457c29b92083fb
 language: "TypeScript"
 stars: 3
 technologies: ["TypeScript", "AI Agents", "Review Tools"]
+goalDocUrl: "https://github.com/schalkneethling/refined-plan-mode/blob/main/GOAL.md"
+whatAndWhy: "A local review app and protocol for AI coding-agent plans. It exists because long plans need the same kind of anchored, reviewable feedback loop that pull requests give code."
+goalSummary: "Turn agent plans into versioned local artifacts with browser-based line, range, and text-selection comments, structured feedback files, and an explicit approval gate before implementation."
+currentState: "The MVP can read versioned Markdown plans, render them in a browser reviewer, persist draft comments, submit JSON feedback, and mark a plan approved through the .plan-review file convention."
+nextSteps:
+  - "Solidify the local review loop around versioned plans, anchored comments, JSON feedback, and approval."
+  - "Make the reviewer UI faster and more natural for repeated plan review."
+  - "Keep Codex, Claude Code, and future harness integrations behaviorally consistent around the same file protocol."
+contributionGuidance: "Useful contributions improve the local file protocol, reviewer ergonomics, harness instructions, and tests around plan review state transitions. Keep the workflow local-first and easy to recover by reading files."
 ---

--- a/src/content/projects/skills-autoresearch-flue.md
+++ b/src/content/projects/skills-autoresearch-flue.md
@@ -8,4 +8,13 @@ imageUrl: "https://repository-images.githubusercontent.com/1229035215/462a7f1d-5
 language: "TypeScript"
 stars: 12
 technologies: ["TypeScript", "Agents", "Evaluation"]
+goalDocUrl: "https://github.com/schalkneethling/skills-autoresearch-flue/blob/main/GOAL.md"
+whatAndWhy: "A Flue-based research harness for deciding whether agent skills help, how much context they should contain, and when a model no longer needs them. It exists to make skill changes evidence-driven instead of vibes-driven."
+goalSummary: "Run auditable eval loops across producer models, compare no-skill and skill-guided output, inspect scores and costs, and let a researcher agent propose the smallest useful skill change when guidance is justified."
+currentState: "The alpha centers on a release-notes fixture with baseline import, optional research, producer evals, independent judging, score aggregation, cost summaries, and persisted artifacts."
+nextSteps:
+  - "Tighten resume and retry behavior without overwriting audit evidence."
+  - "Keep documentation, examples, schemas, and fixture behavior aligned as the alpha loop changes."
+  - "Explore cross-provider judging after the single-provider flow is stable enough for meaningful comparisons."
+contributionGuidance: "Contributions should preserve researcher, producer, and judge separation. Favor small fixtures, schema-validated artifacts, and changes that make evidence easier to inspect by hand."
 ---

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -14,6 +14,8 @@ const { project } = Astro.props;
 const pageTitle = project.data.title;
 const pageDescription = project.data.description;
 const technologies = project.data.technologies ?? [];
+const projectKind =
+  project.data.category === "demo" ? "Little demo" : "Open source project";
 const whatAndWhy = project.data.whatAndWhy ?? project.data.description;
 const goalSummary =
   project.data.goalSummary ??
@@ -64,36 +66,69 @@ const projectLinks = [
   <main class="u-container project-page" id="main-content">
     <p class="back-link"><a href="/projects">Back to What I want to exist</a></p>
     <header class="project-hero">
-      <p class="project-kicker">Project</p>
-      <h1>{pageTitle}</h1>
-      <p class="project-description">{whatAndWhy}</p>
+      <div class="project-hero-copy">
+        <p class="project-kicker">Project dossier</p>
+        <h1>{pageTitle}</h1>
+        <p class="project-description">{whatAndWhy}</p>
 
-      <dl class="project-facts" aria-label="Project facts">
+        <ul class="project-action-list" aria-label="Project links">
+          {
+            projectLinks.map((link) => (
+              <li>
+                <a href={link.href} rel="noopener noreferrer">
+                  {link.label}
+                  <span aria-hidden="true">&rarr;</span>
+                </a>
+              </li>
+            ))
+          }
+        </ul>
+      </div>
+
+      <aside class="project-hero-rail" aria-label="Project summary">
         {
-          project.data.language && (
-            <>
-              <dt>Primary language</dt>
-              <dd>{project.data.language}</dd>
-            </>
+          project.data.imageUrl && (
+            <figure class="project-artifact">
+              <img
+                src={project.data.imageUrl}
+                alt={`${pageTitle} project card`}
+                loading="eager"
+              />
+              <figcaption>Project artifact</figcaption>
+            </figure>
           )
         }
-        <dt>Kind</dt>
-        <dd>{project.data.category === "demo" ? "Little demo" : "Open source project"}</dd>
-      </dl>
+
+        <dl class="project-facts" aria-label="Project facts">
+          {
+            project.data.language && (
+              <>
+                <dt>Primary language</dt>
+                <dd>{project.data.language}</dd>
+              </>
+            )
+          }
+          <dt>Kind</dt>
+          <dd>{projectKind}</dd>
+        </dl>
+      </aside>
     </header>
 
-    <section class="project-section project-section--lead" aria-labelledby="goal">
+    <section class="project-goal" aria-labelledby="goal">
+      <p class="section-kicker">What it is trying to make true</p>
       <h2 id="goal">Goal</h2>
       <p>{goalSummary}</p>
     </section>
 
-    <div class="project-split">
-      <section class="project-section" aria-labelledby="current-state">
+    <div class="project-status-grid">
+      <section class="project-section project-section--status" aria-labelledby="current-state">
+        <p class="section-kicker">Now</p>
         <h2 id="current-state">Where it is</h2>
         <p>{currentState}</p>
       </section>
 
-      <section class="project-section" aria-labelledby="next-steps">
+      <section class="project-section project-section--next" aria-labelledby="next-steps">
+        <p class="section-kicker">Next</p>
         <h2 id="next-steps">What comes next</h2>
         <ul class="next-step-list">
           {nextSteps.map((nextStep) => <li>{nextStep}</li>)}
@@ -101,58 +136,72 @@ const projectLinks = [
       </section>
     </div>
 
-    <section class="project-section" aria-labelledby="technologies">
-      <h2 id="technologies">Technologies used</h2>
-      {
-        technologies.length > 0 ? (
-          <ul class="technology-list">
-            {technologies.map((technology) => <li>{technology}</li>)}
-          </ul>
-        ) : (
-          <p>Technology notes will be added as this project page is expanded.</p>
-        )
-      }
-    </section>
-
-    <section class="project-section" aria-labelledby="contributing">
-      <h2 id="contributing">How people can get involved</h2>
-      <p>{contributionGuidance}</p>
-    </section>
-
-    <section class="project-section project-section--links" aria-labelledby="project-links">
-      <h2 id="project-links">Project links</h2>
-      <ul class="project-link-list">
+    <div class="project-detail-grid">
+      <section class="project-section project-section--tools" aria-labelledby="technologies">
+        <p class="section-kicker">Materials</p>
+        <h2 id="technologies">Technologies used</h2>
         {
-          projectLinks.map((link) => (
-            <li>
-              <a href={link.href} rel="noopener noreferrer">
-                {link.label}
-                <span aria-hidden="true">&rarr;</span>
-              </a>
-            </li>
-          ))
+          technologies.length > 0 ? (
+            <ul class="technology-list">
+              {technologies.map((technology) => <li>{technology}</li>)}
+            </ul>
+          ) : (
+            <p>Technology notes will be added as this project page is expanded.</p>
+          )
         }
-      </ul>
-    </section>
+      </section>
+
+      <section class="project-section project-section--contributing" aria-labelledby="contributing">
+        <p class="section-kicker">Invitation</p>
+        <h2 id="contributing">How people can get involved</h2>
+        <p>{contributionGuidance}</p>
+        <a class="contribution-link" href={project.data.repoUrl} rel="noopener noreferrer">
+          Visit the repository
+          <span aria-hidden="true">&rarr;</span>
+        </a>
+      </section>
+    </div>
   </main>
 </BaseLayout>
 
 <style>
   .project-page {
     --project-rule: var(--size-1) solid var(--color-border);
+    --project-rail-size: 24rem;
   }
 
   .back-link {
-    margin-block-end: var(--size-24);
+    margin-block-end: var(--size-32);
   }
 
   .project-hero {
-    border-block-end: var(--project-rule);
+    align-items: start;
+    border-block-end: var(--size-4) solid var(--color-accent);
     display: grid;
-    gap: var(--size-24);
+    gap: var(--size-32);
     grid-template-columns: 1fr;
-    margin-block-end: var(--spacing-section-default);
-    padding-block-end: var(--size-32);
+    margin-block-end: var(--size-48);
+    padding-block-end: var(--size-40);
+    position: relative;
+  }
+
+  .project-hero::before {
+    background:
+      linear-gradient(
+        90deg,
+        var(--color-link) 0 50%,
+        var(--color-accent) 50% 100%
+      );
+    block-size: var(--size-4);
+    content: "";
+    inline-size: min(16rem, 100%);
+    inset-block-end: calc(var(--size-4) * -1);
+    inset-inline-start: 0;
+    position: absolute;
+  }
+
+  .project-hero-copy {
+    min-inline-size: 0;
   }
 
   .project-kicker {
@@ -165,62 +214,181 @@ const projectLinks = [
   }
 
   .project-hero h1 {
+    line-height: 0.95;
     margin-block: 0;
+    max-inline-size: 11ch;
   }
 
   .project-description {
     font-size: var(--typography-size-small-medium);
-    margin-block: 0;
-    max-inline-size: 64ch;
+    line-height: 1.7;
+    margin-block: var(--size-24) 0;
+    max-inline-size: 48ch;
+  }
+
+  .project-action-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--size-12);
+    list-style: none;
+    margin-block: var(--size-32) 0;
+    padding: 0;
+  }
+
+  .project-action-list a,
+  .contribution-link {
+    align-items: center;
+    border: var(--size-1) solid var(--color-border);
+    border-radius: var(--border-radius-default);
+    display: inline-flex;
+    gap: var(--size-8);
+    min-block-size: 2.75rem;
+    padding: var(--size-8) var(--size-12);
+    text-decoration: none;
+  }
+
+  .project-action-list li:first-child a {
+    background: var(--color-accent);
+    border-color: var(--color-accent);
+    color: var(--color-background);
+  }
+
+  .project-action-list a:hover,
+  .project-action-list a:focus-visible,
+  .contribution-link:hover,
+  .contribution-link:focus-visible {
+    border-color: var(--color-accent);
+    transform: translateY(-1px);
+  }
+
+  .project-action-list li:first-child a:hover,
+  .project-action-list li:first-child a:focus-visible {
+    background: var(--color-accent-hover);
+    border-color: var(--color-accent-hover);
+  }
+
+  .project-action-list span,
+  .contribution-link span {
+    transition: transform 160ms ease;
+  }
+
+  .project-action-list a:hover span,
+  .project-action-list a:focus-visible span,
+  .contribution-link:hover span,
+  .contribution-link:focus-visible span {
+    transform: translateX(var(--size-2));
+  }
+
+  .project-hero-rail {
+    display: grid;
+    gap: var(--size-24);
+    inline-size: 100%;
+  }
+
+  .project-artifact {
+    background: var(--color-surface);
+    border: var(--size-1) solid var(--color-border);
+    border-block-start: var(--size-4) solid var(--color-accent);
+    border-radius: var(--border-radius-default);
+    margin: 0;
+    overflow: hidden;
+  }
+
+  .project-artifact img {
+    aspect-ratio: 1200 / 630;
+    display: block;
+    inline-size: 100%;
+    object-fit: cover;
+  }
+
+  .project-artifact figcaption {
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-size: var(--typography-sm-font-size);
+    padding: var(--size-8) var(--size-12);
   }
 
   .project-facts {
-    border-inline-start: var(--size-4) solid var(--color-accent);
+    background:
+      linear-gradient(var(--color-surface), var(--color-surface)) padding-box,
+      linear-gradient(90deg, var(--color-link), var(--color-accent)) border-box;
+    border: var(--size-1) solid transparent;
+    border-radius: var(--border-radius-default);
     display: grid;
-    gap: var(--size-4) var(--size-16);
-    grid-template-columns: max-content 1fr;
+    gap: var(--size-12);
+    grid-template-columns: 1fr;
     margin: 0;
-    padding-inline-start: var(--size-16);
+    padding: var(--size-16);
   }
 
   .project-facts dt {
     color: var(--color-text-muted);
     font-size: var(--typography-sm-font-size);
+    font-weight: 700;
+    text-transform: uppercase;
   }
 
   .project-facts dd {
-    margin: 0;
+    margin: calc(var(--size-8) * -1) 0 0;
   }
 
-  .project-section {
-    border-block-start: var(--project-rule);
-    padding-block-start: var(--size-24);
+  .section-kicker {
+    color: var(--color-accent);
+    font-size: var(--typography-sm-font-size);
+    font-weight: 700;
+    letter-spacing: 0;
+    margin-block: 0 var(--size-8);
+    text-transform: uppercase;
   }
 
-  .project-section + .project-section,
-  .project-split + .project-section,
-  .project-section + .project-split {
-    margin-block-start: var(--spacing-section-default);
+  .project-goal {
+    border-block-end: var(--project-rule);
+    margin-block-end: var(--size-48);
+    padding-block-end: var(--size-48);
   }
 
+  .project-goal h2,
   .project-section h2 {
-    margin-block-start: 0;
+    margin-block: 0 var(--size-16);
   }
 
-  .project-section--lead {
-    border-block-start: 0;
-    padding-block-start: 0;
+  .project-goal p:last-child {
+    font-family: var(--minimalist-typography-heading-family);
+    font-size: var(--typography-size-small-medium);
+    line-height: 1.5;
+    margin-block: 0;
+    max-inline-size: 50ch;
   }
 
-  .project-split {
+  .project-status-grid,
+  .project-detail-grid {
     display: grid;
     gap: var(--size-32);
     grid-template-columns: 1fr;
-    margin-block-start: var(--spacing-section-default);
+  }
+
+  .project-detail-grid {
+    border-block-start: var(--project-rule);
+    margin-block-start: var(--size-48);
+    padding-block-start: var(--size-48);
+  }
+
+  .project-section {
+    min-inline-size: 0;
+  }
+
+  .project-section--next {
+    border-inline-start: var(--size-4) solid var(--color-accent);
+    padding-inline-start: var(--size-24);
   }
 
   .next-step-list {
+    margin: 0;
     padding-inline-start: var(--size-24);
+  }
+
+  .next-step-list li + li {
+    margin-block-start: var(--size-12);
   }
 
   .technology-list {
@@ -228,56 +396,45 @@ const projectLinks = [
     flex-wrap: wrap;
     gap: var(--size-8);
     list-style: none;
+    margin: 0;
     padding: 0;
   }
 
   .technology-list li {
+    background: var(--color-surface);
     border: var(--size-1) solid var(--color-border);
     border-radius: var(--border-radius-default);
-    padding: var(--size-4) var(--size-8);
+    padding: var(--size-6) var(--size-12);
   }
 
-  .project-link-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--size-16);
-    list-style: none;
-    padding: 0;
-  }
-
-  .project-link-list a {
-    align-items: center;
-    border: var(--size-1) solid var(--color-border);
-    border-radius: var(--border-radius-default);
-    display: inline-flex;
-    gap: var(--size-8);
-    padding: var(--size-8) var(--size-12);
-    text-decoration: none;
-  }
-
-  .project-link-list a:hover,
-  .project-link-list a:focus-visible {
-    border-color: var(--color-accent);
+  .contribution-link {
+    margin-block-start: var(--size-16);
   }
 
   @media (min-width: 48rem) {
     .project-hero {
-      grid-template-columns: minmax(0, 1fr) minmax(14rem, 18rem);
+      grid-template-columns: minmax(0, 1fr) minmax(18rem, var(--project-rail-size));
     }
 
-    .project-kicker,
-    .project-hero h1,
-    .project-description {
-      grid-column: 1;
+    .project-hero-rail {
+      position: sticky;
+      top: var(--size-24);
     }
 
     .project-facts {
-      align-self: end;
-      grid-column: 2;
-      grid-row: 2 / span 2;
+      grid-template-columns: max-content 1fr;
+      gap: var(--size-8) var(--size-16);
     }
 
-    .project-split {
+    .project-facts dd {
+      margin-block-start: 0;
+    }
+
+    .project-status-grid {
+      grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+    }
+
+    .project-detail-grid {
       grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     }
   }

--- a/tests/projectContent.test.ts
+++ b/tests/projectContent.test.ts
@@ -4,6 +4,83 @@ import { describe, expect, it } from "vitest";
 
 const projectsDirectory = path.join(process.cwd(), "src/content/projects");
 
+const starterProjectIds = [
+  "css-community-reset",
+  "ossreleasefeed-v2",
+  "web-platform-pulse",
+  "masonry-gridlanes-wc",
+  "css-expect",
+  "css-property-type-validator",
+  "create-project-calavera",
+  "css-benchpress",
+  "css-custom-property-inspector",
+  "common-components",
+  "css-media-pseudo-polyfill",
+  "skills-autoresearch-flue",
+  "refined-plan-mode",
+];
+
+const projectGoalDocs = new Map([
+  [
+    "masonry-gridlanes-wc",
+    "https://github.com/schalkneethling/masonry-gridlanes-wc/blob/main/GOAL.md",
+  ],
+  [
+    "css-expect",
+    "https://github.com/schalkneethling/css-expect/blob/main/GOAL.md",
+  ],
+  [
+    "css-property-type-validator",
+    "https://github.com/schalkneethling/css-property-type-validator/blob/main/GOAL.md",
+  ],
+  [
+    "create-project-calavera",
+    "https://github.com/schalkneethling/create-project-calavera/blob/main/GOAL.md",
+  ],
+  [
+    "css-benchpress",
+    "https://github.com/schalkneethling/css-benchpress/blob/main/GOAL.md",
+  ],
+  [
+    "common-components",
+    "https://github.com/schalkneethling/common-components/blob/main/GOAL.md",
+  ],
+  [
+    "skills-autoresearch-flue",
+    "https://github.com/schalkneethling/skills-autoresearch-flue/blob/main/GOAL.md",
+  ],
+  [
+    "refined-plan-mode",
+    "https://github.com/schalkneethling/refined-plan-mode/blob/main/GOAL.md",
+  ],
+]);
+
+const projectRoadmaps = new Map([
+  [
+    "css-property-type-validator",
+    "https://github.com/schalkneethling/css-property-type-validator/blob/main/ROADMAP.md",
+  ],
+  [
+    "common-components",
+    "https://github.com/schalkneethling/common-components/blob/main/ROADMAP.md",
+  ],
+]);
+
+const projectLiveUrls = new Map([
+  [
+    "css-property-type-validator",
+    "https://typedcss-validator.schalkneethling.com",
+  ],
+  ["create-project-calavera", "https://calavera.schalkneethling.com"],
+  ["common-components", "https://schalkneethling.github.io/common-components/"],
+]);
+
+const readProjectFile = async (projectId: string) =>
+  fs.readFile(path.join(projectsDirectory, `${projectId}.md`), "utf8");
+
+const missingFrontmatterFields = (contents: string, fields: string[]) =>
+  fields.filter((field) => !new RegExp(`^${field}:`, "m").test(contents));
+
 describe("project content", () => {
   it("defines imageUrl for every curated project card", async () => {
     const filenames = await fs.readdir(projectsDirectory);
@@ -22,5 +99,48 @@ describe("project content", () => {
     }
 
     expect(filesWithoutImages).toEqual([]);
+  });
+
+  it("defines complete starter project detail content", async () => {
+    const requiredFields = [
+      "whatAndWhy",
+      "goalSummary",
+      "currentState",
+      "nextSteps",
+      "contributionGuidance",
+      "technologies",
+    ];
+    const incompleteProjects = [];
+
+    for (const projectId of starterProjectIds) {
+      const contents = await readProjectFile(projectId);
+      const missingFields = missingFrontmatterFields(contents, requiredFields);
+
+      if (missingFields.length > 0) {
+        incompleteProjects.push({ projectId, missingFields });
+      }
+    }
+
+    expect(incompleteProjects).toEqual([]);
+  });
+
+  it("links starter project docs and live URLs where they are currently available", async () => {
+    for (const [projectId, goalDocUrl] of projectGoalDocs) {
+      const contents = await readProjectFile(projectId);
+
+      expect(contents).toContain(`goalDocUrl: "${goalDocUrl}"`);
+    }
+
+    for (const [projectId, roadmapDocUrl] of projectRoadmaps) {
+      const contents = await readProjectFile(projectId);
+
+      expect(contents).toContain(`roadmapDocUrl: "${roadmapDocUrl}"`);
+    }
+
+    for (const [projectId, liveUrl] of projectLiveUrls) {
+      const contents = await readProjectFile(projectId);
+
+      expect(contents).toContain(`liveUrl: "${liveUrl}"`);
+    }
   });
 });

--- a/tests/projects.spec.ts
+++ b/tests/projects.spec.ts
@@ -41,3 +41,55 @@ test("/projects renders image headers for project cards", async ({ page }) => {
     /opengraph\.githubassets\.com|repository-images\.githubusercontent\.com/,
   );
 });
+
+test("project detail pages render project artifacts and links", async ({
+  page,
+}) => {
+  const transparentPng = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+    "base64",
+  );
+
+  await page.route(
+    /https:\/\/(opengraph\.githubassets\.com|repository-images\.githubusercontent\.com)\/.*/,
+    async (route) => {
+      await route.fulfill({
+        body: transparentPng,
+        contentType: "image/png",
+      });
+    },
+  );
+
+  await page.goto("/projects/css-property-type-validator");
+
+  await expect(
+    page.getByRole("heading", { name: "css-property-type-validator" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("img", { name: "css-property-type-validator project card" }),
+  ).toBeVisible();
+  await expect(
+    page.getByLabel("Project facts").getByText("TypeScript"),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("link", { exact: true, name: "Repository" }),
+  ).toHaveAttribute(
+    "href",
+    "https://github.com/schalkneethling/css-property-type-validator",
+  );
+  await expect(
+    page.getByRole("link", { exact: true, name: "Live project" }),
+  ).toHaveAttribute("href", "https://typedcss-validator.schalkneethling.com");
+  await expect(
+    page.getByRole("link", { exact: true, name: "GOAL.md" }),
+  ).toHaveAttribute(
+    "href",
+    "https://github.com/schalkneethling/css-property-type-validator/blob/main/GOAL.md",
+  );
+  await expect(
+    page.getByRole("link", { exact: true, name: "ROADMAP.md" }),
+  ).toHaveAttribute(
+    "href",
+    "https://github.com/schalkneethling/css-property-type-validator/blob/main/ROADMAP.md",
+  );
+});


### PR DESCRIPTION
## Summary
- Completes editorial detail-page content for the remaining starter projects.
- Adds available GOAL.md, ROADMAP.md, and live-site links for the starter projects where GitHub metadata/docs currently expose them.
- Redesigns project detail pages as project dossiers with a stronger hero, project artifact image, facts rail, action links, goal callout, status sections, technologies, and contribution CTA.
- Extends project content and project rendering tests so every main starter project has detail fields and representative detail pages render project artifacts and key links.

## Validation
- pnpm exec vitest run tests/projectContent.test.ts
- pnpm run test:unit
- pnpm run typecheck
- pnpm exec playwright test tests/projects.spec.ts
- pnpm run build
- pnpm run test:a11y

Refs #1346


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project detail pages now show richer project information, including goal, current status, next steps, and contribution guidance.
  * Project pages also surface key links more clearly, such as repository, live site, goal, and roadmap resources.
* **Bug Fixes**
  * Improved the layout and presentation of project detail pages for a cleaner, more consistent browsing experience.
* **Tests**
  * Added coverage to ensure project pages and project metadata display the expected links and details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->