### PR TITLE
Add project-local What I want to exist skill

### DIFF
--- a/.codex/skills/what-i-want-to-exist-projects/SKILL.md
+++ b/.codex/skills/what-i-want-to-exist-projects/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: what-i-want-to-exist-projects
+description: Use when adding, updating, or reviewing entries for the schalkneethling.com "What I want to exist" projects area, including project cards, project detail pages, repo doc cache refreshes, GOAL.md/ROADMAP.md links, and the little demos section.
+---
+
+# What I Want To Exist Projects
+
+Use this skill for changes under `src/content/projects/`, `src/pages/projects*`,
+`src/components/Projects/`, `src/data/project-doc-cache/`, or tests that protect
+the curated project listing and detail pages.
+
+## Workflow
+
+1. Read the current project entry or nearby entries in `src/content/projects/`.
+2. If adding or materially updating a project, inspect the repo, cached docs, and
+   public project page context before writing summaries.
+3. Keep public page copy editorial: summarize `GOAL.md`, `ROADMAP.md`, issues,
+   and repo docs instead of pasting long verbatim source text.
+4. Preserve the current card/detail conventions:
+   - `/projects` remains the listing URL.
+   - Cards link to internal `/projects/{slug}` pages.
+   - Every card needs an `imageUrl`.
+   - `category: "main"` appears in the Projects section.
+   - `category: "demo"` appears in Little demos.
+5. Update tests before implementation when behavior or required content changes.
+6. Run the narrow relevant tests first, then the site checks listed below.
+
+## Adding Or Updating A Project
+
+For schema details and a frontmatter checklist, read
+`references/project-entry.md`.
+
+Use the project slug as the filename in `src/content/projects/{slug}.md`.
+Keep ordering deliberate. Do not automate project ordering unless the user asks.
+
+If repo docs changed, run:
+
+```sh
+pnpm run refresh:project-docs
+```
+
+Review the generated cache diff under `src/data/project-doc-cache/`. The cache
+is source material for editorial summaries, not content rendered directly into
+the public pages.
+
+## Validation
+
+Run the smallest meaningful test first. Common commands:
+
+```sh
+pnpm exec vitest run tests/projectContent.test.ts
+pnpm exec vitest run tests/projectFilters.test.ts tests/projectPages.test.ts
+pnpm exec vitest run tests/projectDocCache.test.ts
+pnpm exec vitest run tests/projectSkill.test.ts
+pnpm run typecheck
+pnpm run build
+pnpm run test:a11y
+```
+
+For listing or detail page UI changes, include the relevant Playwright coverage
+in `tests/projects.spec.ts` and verify accessibility.

--- a/.codex/skills/what-i-want-to-exist-projects/agents/openai.yaml
+++ b/.codex/skills/what-i-want-to-exist-projects/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "What I Want To Exist Projects"
+  short_description: "Maintain curated project pages"
+  default_prompt: "Use $what-i-want-to-exist-projects to add or update a project page."

--- a/.codex/skills/what-i-want-to-exist-projects/references/project-entry.md
+++ b/.codex/skills/what-i-want-to-exist-projects/references/project-entry.md
@@ -1,0 +1,41 @@
+# Project Entry Reference
+
+Project entries live in `src/content/projects/{slug}.md`.
+
+## Required Frontmatter
+
+- `title`: Display name.
+- `description`: Short card summary.
+- `category`: `"main"` for Projects or `"demo"` for Little demos.
+- `order`: Integer used for deliberate listing order.
+- `repoUrl`: GitHub repository URL.
+- `imageUrl`: Card/detail visual. Prefer the repo OpenGraph image when present.
+
+## Optional Frontmatter
+
+- `language`: Primary language shown on cards/detail facts.
+- `stars`: GitHub star count shown on cards.
+- `liveUrl`: Live site or demo URL when available.
+- `goalDocUrl`: Public GitHub link to `GOAL.md` when available.
+- `roadmapDocUrl`: Public GitHub link to `ROADMAP.md` when available.
+- `technologies`: Short list of project technologies.
+- `whatAndWhy`: Editorial "what and why" detail-page summary.
+- `goalSummary`: Editorial summary of the project goal.
+- `currentState`: Where the project is now.
+- `nextSteps`: Short list of what comes next.
+- `contributionGuidance`: How people can help.
+
+## Content Rules
+
+- Use editorial summaries, not pasted repo docs.
+- Keep summaries concrete and written in the site’s voice.
+- Prefer links to `GOAL.md` and `ROADMAP.md` over duplicating full documents.
+- Make missing docs visible only when useful; do not invent links.
+- Keep detail content complete for `category: "main"` starter-style projects.
+
+## Tests To Consider
+
+- `tests/projectContent.test.ts`: required project fields, doc links, live URLs.
+- `tests/projectFilters.test.ts`: category grouping and ordering.
+- `tests/projectPages.test.ts`: internal project URL helpers.
+- `tests/projects.spec.ts`: listing/detail rendering and accessibility-related UI.

--- a/tests/projectSkill.test.ts
+++ b/tests/projectSkill.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const skillDirectory = path.join(
+  process.cwd(),
+  ".codex/skills/what-i-want-to-exist-projects",
+);
+
+async function readSkillFile(relativePath: string) {
+  return fs.readFile(path.join(skillDirectory, relativePath), "utf8");
+}
+
+function parseFrontmatter(markdown: string) {
+  const match = markdown.match(/^---\n(?<frontmatter>[\s\S]*?)\n---/);
+
+  if (!match?.groups?.frontmatter) {
+    throw new Error("Missing frontmatter");
+  }
+
+  const frontmatter: Record<string, string> = {};
+
+  for (const line of match.groups.frontmatter.split("\n")) {
+    const lineMatch = line.match(/^(?<key>[a-z-]+):\s*(?<value>.+)$/);
+
+    if (lineMatch?.groups) {
+      frontmatter[lineMatch.groups.key] = lineMatch.groups.value;
+    }
+  }
+
+  return frontmatter;
+}
+
+describe("what-i-want-to-exist-projects skill", () => {
+  it("passes the core skill-creator frontmatter constraints", async () => {
+    const skill = await readSkillFile("SKILL.md");
+    const frontmatter = parseFrontmatter(skill);
+
+    expect(Object.keys(frontmatter).sort()).toEqual(["description", "name"]);
+    expect(frontmatter.name).toBe("what-i-want-to-exist-projects");
+    expect(frontmatter.name).toMatch(/^[a-z0-9-]+$/);
+    expect(frontmatter.description).toBeTypeOf("string");
+    expect(frontmatter.description).not.toMatch(/[<>]/);
+    expect(frontmatter.description.length).toBeLessThanOrEqual(1024);
+  });
+
+  it("defines trigger metadata for project content work", async () => {
+    const skill = await readSkillFile("SKILL.md");
+
+    expect(skill).toContain("name: what-i-want-to-exist-projects");
+    expect(skill).toContain("src/content/projects/");
+    expect(skill).toContain("src/data/project-doc-cache/");
+    expect(skill).toContain("GOAL.md/ROADMAP.md");
+  });
+
+  it("documents the repeatable project update workflow", async () => {
+    const skill = await readSkillFile("SKILL.md");
+
+    expect(skill).toContain("Cards link to internal `/projects/{slug}` pages.");
+    expect(skill).toContain("Every card needs an `imageUrl`.");
+    expect(skill).toContain("pnpm run refresh:project-docs");
+    expect(skill).toContain("pnpm run test:a11y");
+  });
+
+  it("includes project-entry reference details and UI metadata", async () => {
+    const reference = await readSkillFile("references/project-entry.md");
+    const metadata = await readSkillFile("agents/openai.yaml");
+
+    expect(reference).toContain("Project entries live in");
+    expect(reference).toContain("whatAndWhy");
+    expect(reference).toContain("tests/projectContent.test.ts");
+    expect(metadata).toContain("display_name: \"What I Want To Exist Projects\"");
+    expect(metadata).toContain(
+      "default_prompt: \"Use $what-i-want-to-exist-projects",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a project-local Codex skill for maintaining the What I want to exist project listing and detail pages.
- Documents the repeatable workflow for adding/updating project entries, preserving card/detail conventions, refreshing cached repo docs, and running validation.
- Adds a small project-entry reference file for frontmatter and content expectations.
- Adds unit coverage to keep the skill metadata, workflow references, and UI metadata valid.

## Validation
- pnpm exec vitest run tests/projectSkill.test.ts
- pnpm run test:unit
- pnpm run typecheck
- pnpm run build
- pnpm run test:a11y

## Notes
- The skill-creator quick_validate.py script was attempted, but both available Python runtimes are missing PyYAML. The new unit test mirrors its core frontmatter constraints and validates the project-specific workflow references.

Refs #1348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating and updating project pages, including required fields, content conventions, and review steps.
  * Clarified how project details should be written and what information should appear on listing and detail pages.
* **Tests**
  * Added checks to help ensure the new project workflow documentation stays complete and consistent.
  * Validated skill configuration details and key references used by the project workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->